### PR TITLE
Fix a bug where you couldn’t remove the first language

### DIFF
--- a/Command/RemoveTranslationCommand.php
+++ b/Command/RemoveTranslationCommand.php
@@ -184,10 +184,11 @@ class RemoveTranslationCommand extends ContainerAwareCommand
         foreach ($versionInfo->languageCodes as $languageCode) {
             if (!$newMainLanguage && $languageCode != $this->removeLanguage)
                 $newMainLanguage = $languageCode;
-            if (!$newMainLanguage) {
-                $output->writeln("<error>Error</error>: No translations left if <info>" . $this->removeLanguage . "</info> is removed.");
-                return;
-            }
+        }
+
+        if (!$newMainLanguage) {
+            $output->writeln("<error>Error</error>: No translations left if <info>" . $this->removeLanguage . "</info> is removed.");
+            return;
         }
 
         if(!$this->disableRemoveConfirmation) {


### PR DESCRIPTION
The code didn’t loop over all available languages to find a new main language, and threw an error if you tried to remove the first occuring language.